### PR TITLE
Update Alpine Linux base image to 3.15.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ WORKDIR /app
 RUN go mod download
 RUN go build
 
-FROM alpine:3.15.3
+FROM alpine:3.15.4
 COPY --from=builder /app/ext-authz-server /app/server
 CMD ["/app/server"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Update Alpine Linux base image to 3.15.4

**Which issue(s) this PR fixes**:
[CVE-2022-28391](https://security.alpinelinux.org/vuln/CVE-2022-28391)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
