### PR TITLE
use distroless image for ext-authz-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ WORKDIR /app
 RUN go mod download
 RUN go build
 
-FROM alpine:3.15.4
+FROM gcr.io/distroless/static-debian11:nonroot
+WORKDIR /
+
 COPY --from=builder /app/ext-authz-server /app/server
 CMD ["/app/server"]


### PR DESCRIPTION
**How to categorize this PR?**

/area networking security open-source
/kind enhancement

**What this PR does / why we need it**:
This PR changes the base image for the external authorization server from alpine to [distroless](https://github.com/GoogleContainerTools/distroless). The processes will now use a non root user for their execution. This will reduce the attack surface of the images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The ext-authz-server now uses `distroless` instead of `alpine` as a base image.
```
