### PR TITLE
Support multiple vpn-seed-servers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ EXTERNAL_AUTHZ_SERVER_IMAGE_TAG        := $(VERSION)
 ext-authz-server-docker-image:
 	@docker build -t $(EXTERNAL_AUTHZ_SERVER_IMAGE_REPOSITORY):$(EXTERNAL_AUTHZ_SERVER_IMAGE_TAG) -f Dockerfile --rm .
 
+.PHONY: test
+test:
+	go test ./pkg/...
+
 .PHONY: docker-images
 docker-images: ext-authz-server-docker-image
 

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 	auth_v3 "github.com/gardener/ext-authz-server/pkg/auth/v3"
 )
 
-const service auth.Services = `^outbound\|1194\|\|vpn-seed-server\..*\.svc\.cluster\.local$`
+const service auth.Services = `^outbound\|1194\|\|vpn-seed-server(-[0-4])?\..*\.svc\.cluster\.local$`
 
 func main() {
 	port := flag.Int("port", 9001, "gRPC port")

--- a/pkg/auth/services_test.go
+++ b/pkg/auth/services_test.go
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package auth
+
+import "testing"
+
+const service Services = `^outbound\|1194\|\|vpn-seed-server(-[0-4])?\..*\.svc\.cluster\.local$`
+
+func TestCheck(t *testing.T) {
+	type testdata struct {
+		svc           string
+		expectedMatch bool
+	}
+	tests := []testdata{
+		{"outbound|1194||vpn-seed-server.foo.svc.cluster.local", true},
+		{"outbound|1194||vpn-seed-server-0.foo.svc.cluster.local", true},
+		{"outbound|1194||vpn-seed-server-2.foo.svc.cluster.local", true},
+		{"outbound|1194||vpn-seed-server-11.foo.svc.cluster.local", false},
+		{"outbound|1194||vpn-seed-server.foo.svc.cluster.local.bar", false},
+	}
+
+	for _, test := range tests {
+		match, err := service.Check(test.svc)
+		if err != nil {
+			t.Errorf("%s failed: %s", test.svc, err)
+			continue
+		}
+		if match != test.expectedMatch {
+			t.Errorf("%s match mismatch: expected %t", test.svc, test.expectedMatch)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow multiple vpn-seed-servers with suffix `-0`... `-4`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Part of https://github.com/gardener/gardener/issues/6890

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Support multiple vpn-seed-servers
```
