### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -5,6 +5,7 @@ ext-authz-server:
         image: 'golang:1.21.3'
     traits:
       component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
         component_labels:
         - name: 'cloud.gardener.cnudie/responsibles'
           value:
@@ -20,7 +21,7 @@ ext-authz-server:
         - linux/arm64
         dockerimages:
           ext-authz-server:
-            image: 'eu.gcr.io/gardener-project/gardener/ext-authz-server'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/ext-authz-server
             dockerfile: 'Dockerfile'
             resource_labels:
             - name: 'gardener.cloud/cve-categorisation'
@@ -35,6 +36,9 @@ ext-authz-server:
     head-update:
       traits:
         draft_release: ~
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
     pull-request:
       traits:
         pull-request: ~
@@ -42,6 +46,12 @@ ext-authz-server:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            ext-authz-server:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/ext-authz-server
         release:
           nextversion: 'bump_minor'
         slack:
@@ -50,5 +60,3 @@ ext-authz-server:
             internal_scp_workspace:
               channel_name: 'C9CEBQPGE' #sap-tech-gardener
               slack_cfg_name: 'scp_workspace'
-        component_descriptor:
-          component_name: 'github.com/gardener/ext-authz-server'

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,7 +1,5 @@
 ext-authz-server:
-  template: 'default'
   base_definition:
-    repo: ~
     steps:
       verify:
         image: 'golang:1.21.3'
@@ -22,7 +20,6 @@ ext-authz-server:
         - linux/arm64
         dockerimages:
           ext-authz-server:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ext-authz-server'
             dockerfile: 'Dockerfile'
             resource_labels:

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ revendor:
 	@GO111MODULE=on go mod tidy
 	@GO111MODULE=on go mod vendor
 	@chmod +x $(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/*
-	
+
 .PHONY: check
 check: $(GOIMPORTS) $(GOLANGCI_LINT)
 	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/check.sh ./cmd/... ./pkg/...

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 VERSION                                := $(shell cat VERSION)
-REGISTRY                               := eu.gcr.io/gardener-project/gardener
+REGISTRY                               := europe-docker.pkg.dev/gardener-project/public/gardener
 PREFIX                                 := ext-authz-server
 EXTERNAL_AUTHZ_SERVER_IMAGE_REPOSITORY := $(REGISTRY)/$(PREFIX)
 EXTERNAL_AUTHZ_SERVER_IMAGE_TAG        := $(VERSION)


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
