### PR TITLE
Introduce `gosec` for Static Application Security Testing (SAST)

### DIFF
--- a/.ci/hack/component_descriptor
+++ b/.ci/hack/component_descriptor
@@ -54,6 +54,8 @@ if [[ -f "$repo_root_dir/charts/images.yaml" ]]; then
   image_vector_path="$repo_root_dir/charts/images.yaml"
 elif [[ -f "$repo_root_dir/imagevector/images.yaml" ]]; then
   image_vector_path="$repo_root_dir/imagevector/images.yaml"
+elif [[ -f "$repo_root_dir/imagevector/containers.yaml" ]]; then
+  image_vector_path="$repo_root_dir/imagevector/containers.yaml"
 fi
 
 if [[ ! -z "$image_vector_path" ]]; then
@@ -70,7 +72,7 @@ if [[ ! -z "$image_vector_path" ]]; then
     "
   fi
 
-  # translates all images defined the images.yaml into component descriptor resources.
+  # translates all images defined the containers.yaml into component descriptor resources.
   # For detailed documentation see https://github.com/gardener/component-cli/blob/main/docs/reference/components-cli_image-vector_add.md
   component-cli image-vector add ${COMPONENT_CLI_ARGS}
 fi

--- a/.ci/hack/set_dependency_version
+++ b/.ci/hack/set_dependency_version
@@ -107,7 +107,7 @@ if name in injectedSpecialCases:
 elif name == 'autoscaler':
     names = ['cluster-autoscaler']
 elif name == 'vpn2':
-    names = ['vpn-seed-server', 'vpn-shoot-client']
+    names = ['vpn-server', 'vpn-client']
 elif name == 'external-dns-management':
     names = ['dns-controller-manager']
 elif name == 'logging':

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ hack/tools/bin
 .cache_ggshield
 
 TODO
+
+# gosec
+gosec-report.sarif

--- a/go.sum
+++ b/go.sum
@@ -211,7 +211,6 @@ k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 h1:aVUu9fTY98ivBPKR9Y5w/A
 k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00/go.mod h1:AsvuZPBlUDVuCdzJ87iajxtXuR9oktsTctW/R9wwouA=
 k8s.io/utils v0.0.0-20240902221715-702e33fdd3c3 h1:b2FmK8YH+QEwq/Sy2uAEhmqL5nPfGYbJOcaqjeYYZoA=
 k8s.io/utils v0.0.0-20240902221715-702e33fdd3c3/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-sigs.k8s.io/controller-runtime v0.17.6/go.mod h1:N0jpP5Lo7lMTF9aL56Z/B2oWBJjey6StQM0jRbKQXtY=
 sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20231015215740-bf15e44028f9 h1:O27fSMHw4u0h+Rj8bNzcZk5jY0iZCO0J8/mCpigpnbw=
 sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20231015215740-bf15e44028f9/go.mod h1:TF/lVLWS+JNNaVqJuDDictY2hZSXSsIHCx4FClMvqFg=
 sigs.k8s.io/controller-tools v0.14.0 h1:rnNoCC5wSXlrNoBKKzL70LNJKIQKEzT6lloG6/LF73A=

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+
+gosec_report="false"
+gosec_report_parse_flags=""
+
+parse_flags() {
+  while test $# -gt 1; do
+    case "$1" in
+      --gosec-report)
+        shift; gosec_report="$1"
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
+
+parse_flags "$@"
+
+echo "> Running gosec"
+gosec --version
+if [[ "$gosec_report" != "false" ]]; then
+  echo "Exporting report to $root_dir/gosec-report.sarif"
+  gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=gosec-report.sarif -stdout"
+fi
+
+# Gardener uses code-generators https://github.com/kubernetes/code-generator and https://github.com/protocolbuffers/protobuf
+# which create lots of G103 (CWE-242: Use of unsafe calls should be audited) & G104 (CWE-703: Errors unhandled) errors.
+# However, those generators are best-pratice in Kubernetes environment and their results are tested well.
+# Thus, generated code is excluded from gosec scan.
+# Nested go modules are not supported by gosec (see https://github.com/securego/gosec/issues/501), so the ./hack folder
+# is excluded too. It does not contain productive code anyway.
+gosec -exclude-generated -exclude-dir=hack $gosec_report_parse_flags ./...


### PR DESCRIPTION
/area networking
/area security
/area compliance
/kind enhancement

**What this PR does / why we need it**:

This PR introduces `gosec` for Static Application Security Testing at Gardener and should replace other code scanners.

It uses the default ruleset of `gosec` from gardener/gardener as introduced in https://github.com/gardener/gardener/pull/9959.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Until https://github.com/gardener/gardener/pull/10642 is in a gardener/gardener release there is a small workaround necessary, which will be removed afterwards.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`gosec` was introduced for Static Application Security Testing (SAST).
```
