### PR TITLE
[GEP-30] Note that ext-authz-server is no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ext-authz-server
 
+> [!NOTE]
+> As of https://github.com/gardener/gardener/pull/11328, this component is no longer used. See [GEP-30](https://github.com/gardener/gardener/blob/master/docs/proposals/30-apiserver-proxy.md#reconfiguring-the-istio-ingress-gateway) for more details.
+
 [![REUSE status](https://api.reuse.software/badge/github.com/gardener/ext-authz-server)](https://api.reuse.software/info/github.com/gardener/ext-authz-server)
 
 This repository contains the external authorization server for the envoy.


### PR DESCRIPTION
**What this PR does / why we need it**:

With https://github.com/gardener/gardener/pull/11328, this component is no longer used.

This PR adds an according note to this repository's README.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11214

**Special notes for your reviewer**:

After merging this PR, we can archive this repository.
@rfranzke can you help with that?

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
